### PR TITLE
Update tape and travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# BusterMove [![Build Status](https://secure.travis-ci.org/rvagg/node-bustermove.png)](http://travis-ci.org/rvagg/node-bustermove)
+# BusterMove [![Build Status](https://secure.travis-ci.org/rvagg/bustermove.png)](http://travis-ci.org/rvagg/bustermove)
 
 [![NPM](https://nodei.co/npm/bustermove.png?downloads)](https://nodei.co/npm/bustermove/)
 

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
     "referee": "~1.0.1"
   },
   "peerDependencies": {
-    "tape": "2.x.x",
+    "tape": "4.x.x",
     "tap": "0.x.x"
   },
   "devDependencies": {
-    "tape": "~2.3.2",
+    "tape": "~4.0.0",
     "tap": "~0.4.6",
     "faucet": "0.0.0"
   },

--- a/test.js
+++ b/test.js
@@ -74,6 +74,7 @@ tape('setUp and tearDown', function (t) {
 })
 
 tape('nested', function (t) {
+  t.plan(13)
   tests = []
 
   var holder = {
@@ -158,7 +159,6 @@ tape('nested', function (t) {
         , inner3tearDown : 0
         , inner3main     : 0
     }, 'test has been properly run')
-    t.end()
   }})
 
   t.equal(tests[1].name, 'Test Name: test inner 1: inner')
@@ -175,7 +175,6 @@ tape('nested', function (t) {
         , inner3tearDown : 0
         , inner3main     : 0
     }, 'test has been properly run')
-    t.end()
   }})
 
   t.equal(tests[2].name, 'Test Name: test inner 2: inner')
@@ -192,7 +191,6 @@ tape('nested', function (t) {
         , inner3tearDown : 0
         , inner3main     : 0
     }, 'test has been properly run')
-    t.end()
   }})
 
   t.equal(tests[3].name, 'Test Name: test inner 3: inner')
@@ -209,6 +207,5 @@ tape('nested', function (t) {
         , inner3tearDown : 1
         , inner3main     : 1
     }, 'test has been properly run')
-    t.end()
   }})
 })


### PR DESCRIPTION
We need this in order to use the latest `tape` for `levelup` because npm complains when installing `bustermove`

```
$ npm i tape -S
npm ERR! Linux 3.16.0-34-generic
npm ERR! argv "/usr/local/bin/iojs" "/usr/local/bin/npm" "i" "tape" "-S"
npm ERR! node v1.8.1
npm ERR! npm  v2.8.3
npm ERR! code EPEERINVALID

npm ERR! peerinvalid The package tape does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer bustermove@0.4.1 wants tape@~2.3.0

npm ERR! Please include the following file with any support request:
npm ERR!     /home/lms/src/leveldb-repos/levelup/npm-debug.log
```

/cc @rvagg @mcollina @juliangruber