### PR TITLE
peerDependencies: bump tap

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,18 +22,17 @@
   },
   "peerDependencies": {
     "tape": "4.x.x",
-    "tap": "0.x.x"
+    "tap": "2.x.x"
   },
   "devDependencies": {
-    "tape": "~4.0.0",
-    "tap": "~0.4.6",
-    "faucet": "0.0.0"
+    "tape": "~4.2.2",
+    "tap": "~2.3.1"
   },
   "browser": {
     "tap": false
   },
   "scripts": {
-    "test": "faucet ./test.js"
+    "test": "node test.js"
   },
   "license": "MIT",
   "bin": "./bin.js"


### PR DESCRIPTION
I also removed faucet because it errors because `tap` insists on outputting the following to stdout

```
TAP version 13 
1..0           
# time=81.951ms
```

just by doing `var tap = require('tap')` which is kind of silly:

![tap-output](https://cloud.githubusercontent.com/assets/308049/11427172/508c04a6-9461-11e5-8f74-a4d453ede29f.png)

I tried to find some kind of workaround for this and the simplest I found was simply just to run the tests without faucet.

The reason for this update is so `levelup` can move up to a newer version of bustermove supporting a newer version of tap.
